### PR TITLE
Funkcjonalności API autora książek

### DIFF
--- a/src/main/java/pl/umk/mat/gobooks/authors/Author.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/Author.java
@@ -6,7 +6,9 @@ import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.Where;
+import pl.umk.mat.gobooks.authors.dto.NewAuthor;
 import pl.umk.mat.gobooks.commons.BaseEntity;
+import pl.umk.mat.gobooks.commons.exceptions.BadRequest;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -33,6 +35,17 @@ public class Author extends BaseEntity {
     @Lob
     @Type(type = "org.hibernate.type.TextType")
     private String biography;
+
+    public Author(NewAuthor newAuthor) throws BadRequest {
+        this.firstName = newAuthor.getFirstName();
+        this.lastName = newAuthor.getLastName();
+        try {
+            this.nationality = CountryCode.valueOf(newAuthor.getNationality());
+        } catch (IllegalArgumentException ex) {
+            throw new BadRequest(String.format("Cannot find %s nationality value", newAuthor.getNationality()));
+        }
+        this.birthDate = newAuthor.getBirthDate();
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/pl/umk/mat/gobooks/authors/Author.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/Author.java
@@ -2,6 +2,7 @@ package pl.umk.mat.gobooks.authors;
 
 import com.neovisionaries.i18n.CountryCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Type;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 @Table(name = "authors")
 @Getter
 @Setter
+@NoArgsConstructor
 @Where(clause = "deleted = false")
 @SQLDelete(sql = "UPDATE authors SET deleted = TRUE WHERE id = ?")
 public class Author extends BaseEntity {

--- a/src/main/java/pl/umk/mat/gobooks/authors/AuthorController.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/AuthorController.java
@@ -2,17 +2,15 @@ package pl.umk.mat.gobooks.authors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import pl.umk.mat.gobooks.authors.dto.AuthorBiography;
 import pl.umk.mat.gobooks.authors.dto.AuthorResponse;
 import pl.umk.mat.gobooks.authors.dto.NewAuthor;
+import pl.umk.mat.gobooks.commons.IterableResponse;
 import pl.umk.mat.gobooks.commons.exceptions.BadRequest;
 
 import javax.validation.Valid;
-import java.io.Serializable;
-import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequestMapping("api/authors")
@@ -22,40 +20,38 @@ public class AuthorController {
     private final AuthorService authorService;
 
     @GetMapping
-    public ResponseEntity<List<AuthorResponse>> getAll(Pageable pageable) {
-        return ResponseEntity.ok(authorService.findAll(pageable));
+    public IterableResponse<AuthorResponse> getAll(Pageable pageable) {
+        return new IterableResponse<>(authorService.findAll(pageable));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<AuthorResponse> getById(@PathVariable Long id) {
-        return ResponseEntity.ok(authorService.findById(id));
+    public AuthorResponse getById(@PathVariable Long id) {
+        return authorService.findById(id);
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<AuthorResponse>> search(
+    public IterableResponse<AuthorResponse> search(
             @RequestParam(defaultValue = "") String firstName,
             @RequestParam(defaultValue = "") String lastName,
             Pageable pageable
     ) {
-        return ResponseEntity.ok(authorService.search(firstName, lastName, pageable));
+        return new IterableResponse<>(authorService.search(firstName, lastName, pageable));
     }
 
     @PostMapping
-    public ResponseEntity<Serializable> save(@RequestBody @Valid NewAuthor newAuthor)
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthorResponse save(@RequestBody @Valid NewAuthor newAuthor)
             throws BadRequest {
-        return ResponseEntity
-                .created(URI.create("/authors/" + authorService.save(newAuthor)))
-                .build();
+        return authorService.save(newAuthor);
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<AuthorResponse> updateBiography(@PathVariable Long id, @RequestBody @Valid AuthorBiography biography) {
-        return ResponseEntity.ok(authorService.updateBiography(id, biography));
+    public AuthorResponse updateBiography(@PathVariable Long id, @RequestBody @Valid AuthorBiography biography) {
+        return authorService.updateBiography(id, biography);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Serializable> delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id) {
         authorService.delete(id);
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/pl/umk/mat/gobooks/authors/AuthorController.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/AuthorController.java
@@ -1,0 +1,61 @@
+package pl.umk.mat.gobooks.authors;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pl.umk.mat.gobooks.authors.dto.AuthorBiography;
+import pl.umk.mat.gobooks.authors.dto.AuthorResponse;
+import pl.umk.mat.gobooks.authors.dto.NewAuthor;
+import pl.umk.mat.gobooks.commons.exceptions.BadRequest;
+
+import javax.validation.Valid;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("api/authors")
+@RequiredArgsConstructor
+public class AuthorController {
+
+    private final AuthorService authorService;
+
+    @GetMapping
+    public ResponseEntity<List<AuthorResponse>> getAll(Pageable pageable) {
+        return ResponseEntity.ok(authorService.findAll(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AuthorResponse> getById(@PathVariable Long id) {
+        return ResponseEntity.ok(authorService.findById(id));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<AuthorResponse>> search(
+            @RequestParam(defaultValue = "") String firstName,
+            @RequestParam(defaultValue = "") String lastName,
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(authorService.search(firstName, lastName, pageable));
+    }
+
+    @PostMapping
+    public ResponseEntity<Serializable> save(@RequestBody @Valid NewAuthor newAuthor)
+            throws BadRequest {
+        return ResponseEntity
+                .created(URI.create("/authors/" + authorService.save(newAuthor)))
+                .build();
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<AuthorResponse> updateBiography(@PathVariable Long id, @RequestBody @Valid AuthorBiography biography) {
+        return ResponseEntity.ok(authorService.updateBiography(id, biography));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Serializable> delete(@PathVariable Long id) {
+        authorService.delete(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/pl/umk/mat/gobooks/authors/AuthorRepository.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/AuthorRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import pl.umk.mat.gobooks.commons.BaseRepository;
 
 @Repository
-interface AuthorRepository extends BaseRepository<Author, Long> {
+public interface AuthorRepository extends BaseRepository<Author, Long> {
 
     Page<Author> findDistinctByFirstNameContainsIgnoreCaseAndLastNameContainsIgnoreCase(
             String firstName, String lastName, Pageable pageable);

--- a/src/main/java/pl/umk/mat/gobooks/authors/AuthorRepository.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/AuthorRepository.java
@@ -1,0 +1,17 @@
+package pl.umk.mat.gobooks.authors;
+
+import com.neovisionaries.i18n.CountryCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import pl.umk.mat.gobooks.commons.BaseRepository;
+
+@Repository
+interface AuthorRepository extends BaseRepository<Author, Long> {
+
+    Page<Author> findDistinctByFirstNameContainsIgnoreCaseAndLastNameContainsIgnoreCase(
+            String firstName, String lastName, Pageable pageable);
+
+    boolean existsByFirstNameEqualsAndLastNameEqualsAndNationalityEquals(
+            String firstName, String lastName, CountryCode nationality);
+}

--- a/src/main/java/pl/umk/mat/gobooks/authors/AuthorService.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/AuthorService.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-class AuthorService {
+public class AuthorService {
 
     private final AuthorRepository authorRepository;
     private final BookRepository bookRepository;
@@ -42,7 +42,7 @@ class AuthorService {
     }
 
     @Transactional
-    public Long save(NewAuthor newAuthor) {
+    public AuthorResponse save(NewAuthor newAuthor) {
         CountryCode nationality;
         try {
             nationality = CountryCode.valueOf(newAuthor.getNationality());
@@ -53,7 +53,7 @@ class AuthorService {
                 newAuthor.getFirstName(), newAuthor.getLastName(), nationality)) {
             throw new ResourceAlreadyExist();
         }
-        return authorRepository.save(new Author(newAuthor)).getId();
+        return new AuthorResponse(authorRepository.save(new Author(newAuthor)));
     }
 
     @Transactional

--- a/src/main/java/pl/umk/mat/gobooks/authors/AuthorService.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/AuthorService.java
@@ -1,0 +1,74 @@
+package pl.umk.mat.gobooks.authors;
+
+import com.neovisionaries.i18n.CountryCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import pl.umk.mat.gobooks.authors.dto.AuthorBiography;
+import pl.umk.mat.gobooks.authors.dto.AuthorResponse;
+import pl.umk.mat.gobooks.authors.dto.NewAuthor;
+import pl.umk.mat.gobooks.books.BookRepository;
+import pl.umk.mat.gobooks.commons.exceptions.BadRequest;
+import pl.umk.mat.gobooks.commons.exceptions.ResourceAlreadyExist;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+class AuthorService {
+
+    private final AuthorRepository authorRepository;
+    private final BookRepository bookRepository;
+
+    public List<AuthorResponse> findAll(Pageable pageable) {
+        return authorRepository.findAll(pageable).stream()
+                .map(AuthorResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public AuthorResponse findById(Long id) {
+        return new AuthorResponse(authorRepository.findByIdOrThrow(id));
+    }
+
+    public List<AuthorResponse> search(String firstName, String lastName, Pageable pageable) {
+        return authorRepository
+                .findDistinctByFirstNameContainsIgnoreCaseAndLastNameContainsIgnoreCase(
+                        firstName, lastName, pageable)
+                .stream()
+                .map(AuthorResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Long save(NewAuthor newAuthor) {
+        CountryCode nationality;
+        try {
+            nationality = CountryCode.valueOf(newAuthor.getNationality());
+        } catch (IllegalArgumentException ex) {
+            throw new BadRequest(String.format("Cannot find %s nationality value", newAuthor.getNationality()));
+        }
+        if (authorRepository.existsByFirstNameEqualsAndLastNameEqualsAndNationalityEquals(
+                newAuthor.getFirstName(), newAuthor.getLastName(), nationality)) {
+            throw new ResourceAlreadyExist();
+        }
+        return authorRepository.save(new Author(newAuthor)).getId();
+    }
+
+    @Transactional
+    public AuthorResponse updateBiography(Long id, AuthorBiography biography) {
+        var author = authorRepository.findByIdOrThrow(id);
+        author.setBiography(biography.getBiography());
+        return new AuthorResponse(authorRepository.save(author));
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        var author = authorRepository.findByIdOrThrow(id);
+        if (bookRepository.existsByAuthor(author)) {
+            throw new BadRequest("Cannot remove author with books");
+        }
+        authorRepository.delete(author);
+    }
+}

--- a/src/main/java/pl/umk/mat/gobooks/authors/dto/AuthorBiography.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/dto/AuthorBiography.java
@@ -1,0 +1,12 @@
+package pl.umk.mat.gobooks.authors.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+public class AuthorBiography {
+
+    @NotEmpty
+    private String biography;
+}

--- a/src/main/java/pl/umk/mat/gobooks/authors/dto/AuthorResponse.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/dto/AuthorResponse.java
@@ -1,0 +1,21 @@
+package pl.umk.mat.gobooks.authors.dto;
+
+import com.neovisionaries.i18n.CountryCode;
+import lombok.Getter;
+import pl.umk.mat.gobooks.authors.Author;
+
+@Getter
+public class AuthorResponse {
+
+    private final String firstName;
+    private final String lastName;
+    private final CountryCode nationality;
+    private final String biography;
+
+    public AuthorResponse(Author author) {
+        this.firstName = author.getFirstName();
+        this.lastName = author.getLastName();
+        this.nationality = author.getNationality();
+        this.biography = author.getBiography();
+    }
+}

--- a/src/main/java/pl/umk/mat/gobooks/authors/dto/NewAuthor.java
+++ b/src/main/java/pl/umk/mat/gobooks/authors/dto/NewAuthor.java
@@ -1,0 +1,16 @@
+package pl.umk.mat.gobooks.authors.dto;
+
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+public class NewAuthor {
+
+    private String firstName;
+    private String lastName;
+    private String nationality;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthDate;
+}

--- a/src/main/java/pl/umk/mat/gobooks/books/BookRepository.java
+++ b/src/main/java/pl/umk/mat/gobooks/books/BookRepository.java
@@ -1,0 +1,10 @@
+package pl.umk.mat.gobooks.books;
+
+import org.springframework.stereotype.Repository;
+import pl.umk.mat.gobooks.authors.Author;
+import pl.umk.mat.gobooks.commons.BaseRepository;
+
+@Repository
+public interface BookRepository extends BaseRepository<Book, Long> {
+    boolean existsByAuthor(Author author);
+}

--- a/src/main/java/pl/umk/mat/gobooks/commons/BaseRepository.java
+++ b/src/main/java/pl/umk/mat/gobooks/commons/BaseRepository.java
@@ -1,5 +1,6 @@
 package pl.umk.mat.gobooks.commons;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import pl.umk.mat.gobooks.commons.exceptions.ResourceNotFound;
@@ -22,4 +23,6 @@ public interface BaseRepository<T, ID> extends JpaRepository<T, ID> {
     default List<T> findAllList() {
         return new ArrayList<>(this.findAll());
     }
+
+    default List<T> findAllList(Pageable pageable) { return new ArrayList<>(this.findAll(pageable).toList()); }
 }

--- a/src/main/java/pl/umk/mat/gobooks/commons/IterableResponse.java
+++ b/src/main/java/pl/umk/mat/gobooks/commons/IterableResponse.java
@@ -1,0 +1,13 @@
+package pl.umk.mat.gobooks.commons;
+
+import lombok.Getter;
+
+@Getter
+public class IterableResponse<T> {
+
+    private final Iterable<T> values;
+
+    public IterableResponse(Iterable<T> values) {
+        this.values = values;
+    }
+}


### PR DESCRIPTION
Dodano kontroler, serwis, repozytoria oraz obiekty transportowe obsługujące żądania dotyczące autora książek:

- pobranie wszystkich autorów z paginacją
- pobranie autora po ID
- wyszukanie autora po imieniu i nazwisku
- stworzenie nowego autora
- edycja biografii istniejącego autora
- usunięcie istniejącego autora (zmiana flagi na usunięty)